### PR TITLE
feat: add reusable button component

### DIFF
--- a/client/src/components/Button.jsx
+++ b/client/src/components/Button.jsx
@@ -1,0 +1,26 @@
+import clsx from 'clsx'
+import styles from './Button.module.css'
+
+export default function Button({
+  as: Component = 'button',
+  variant = 'secondary',
+  size = 'md',
+  loading = false,
+  className,
+  disabled,
+  ...props
+}) {
+  return (
+    <Component
+      className={clsx(
+        styles.btn,
+        styles[variant],
+        styles[size],
+        loading && styles.loading,
+        className,
+      )}
+      disabled={disabled ?? loading}
+      {...props}
+    />
+  )
+}

--- a/client/src/components/Button.md
+++ b/client/src/components/Button.md
@@ -1,0 +1,25 @@
+# Button Component
+
+Provides a styled button with `variant` and `size` props.
+
+## Variants
+
+- `primary` – highlights the button using the primary color.
+- `secondary` – default button style.
+- `ghost` – transparent background with no border.
+
+## Sizes
+
+- `sm`
+- `md` (default)
+- `lg`
+
+## Usage
+
+```jsx
+import Button from '../components/Button.jsx'
+
+<Button>Default</Button>
+<Button variant="primary">Primary</Button>
+<Button variant="ghost" size="lg">Ghost</Button>
+``` 

--- a/client/src/components/Button.module.css
+++ b/client/src/components/Button.module.css
@@ -1,0 +1,50 @@
+.btn {
+  background: #1b1f2a;
+  border: var(--space-1) solid var(--border);
+  color: var(--text);
+  padding: var(--space-10) var(--space-md);
+  border-radius: var(--space-12);
+  transition: filter .2s;
+}
+
+.btn:focus {
+  outline: none;
+}
+
+.btn:hover {
+  filter: brightness(1.1);
+}
+
+.btn.loading,
+.btn:disabled {
+  opacity: .7;
+  cursor: not-allowed;
+}
+
+.primary {
+  background: var(--primary);
+  border-color: var(--primary);
+  color: #fff;
+}
+
+.secondary {
+}
+
+.ghost {
+  background: transparent;
+  border-color: transparent;
+}
+
+.sm {
+  padding: var(--space-6) var(--space-10);
+  font-size: 0.875rem;
+}
+
+.md {
+  padding: var(--space-10) var(--space-md);
+}
+
+.lg {
+  padding: var(--space-14) var(--space-lg);
+  font-size: 1.125rem;
+}

--- a/client/src/components/Comments.jsx
+++ b/client/src/components/Comments.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useAuth } from '../state/AuthContext.jsx'
+import Button from './Button.jsx'
 
 export default function Comments({ articleId }) {
   const { request, auth, ui } = useAuth()
@@ -49,9 +50,9 @@ export default function Comments({ articleId }) {
         <div className="comment-form">
           <textarea rows={3} placeholder="Write a comment…" value={content} onChange={(e) => setContent(e.target.value)} />
           <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
-            <button className={`btn btn-primary ${posting ? 'loading' : ''}`} disabled={posting || !content.trim()} onClick={() => submit(null)}>
+            <Button variant="primary" loading={posting} disabled={posting || !content.trim()} onClick={() => submit(null)}>
               {posting ? 'Posting…' : 'Post'}
-            </button>
+            </Button>
           </div>
         </div>
       ) : (
@@ -112,30 +113,30 @@ function CommentItem({ c, childMap, me, onReply, onDeleteSuccess }) {
       </div>
       <div className="comment-body">{c.content}</div>
       <div className="comment-actions">
-        {me && <button className="btn" onClick={() => setShow((s) => !s)}>{show ? 'Cancel' : 'Reply'}</button>}
+        {me && <Button onClick={() => setShow((s) => !s)}>{show ? 'Cancel' : 'Reply'}</Button>}
         {me && (
-          <button className="btn" onClick={async()=>{
+          <Button onClick={async()=>{
             try {
               const reason = prompt('Why are you reporting this comment?') || ''
               if (!reason.trim()) return
               await request('/reports', { method:'POST', body: JSON.stringify({ target_type:'comment', target_id: c.id, reason }) })
               ui.notify('Report submitted. Thank you.', 'info')
             } catch {}
-          }}>Report</button>
+          }}>Report</Button>
         )}
         {canDelete && (
-          <button className="btn" onClick={del} disabled={busy}>
+          <Button onClick={del} disabled={busy}>
             {busy ? 'Deleting…' : 'Delete'}
-          </button>
+          </Button>
         )}
       </div>
       {show && (
         <div className="comment-form reply">
           <textarea rows={2} placeholder="Reply…" value={text} onChange={(e) => setText(e.target.value)} />
           <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
-            <button className={`btn btn-primary ${busy ? 'loading' : ''}`} disabled={busy || !text.trim()} onClick={() => onReply(c.id, text, setText)}>
+            <Button variant="primary" loading={busy} disabled={busy || !text.trim()} onClick={() => onReply(c.id, text, setText)}>
               {busy ? 'Posting…' : 'Reply'}
-            </button>
+            </Button>
           </div>
         </div>
       )}

--- a/client/src/components/Footer.jsx
+++ b/client/src/components/Footer.jsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom'
+import Button from './Button.jsx'
 
 export default function Footer() {
   const year = new Date().getFullYear()
@@ -41,7 +42,7 @@ export default function Footer() {
       </div>
       <div className="container footer-bottom">
         <span className="muted">© {year} {app}. All rights reserved.</span>
-        <a href="#top" className="btn" onClick={(e)=>{ e.preventDefault(); window.scrollTo({ top: 0, behavior: 'smooth' }) }}>Back to top ↑</a>
+        <Button as="a" href="#top" onClick={(e)=>{ e.preventDefault(); window.scrollTo({ top: 0, behavior: 'smooth' }) }}>Back to top ↑</Button>
       </div>
     </footer>
   )

--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -1,6 +1,7 @@
 import { Link, useNavigate } from 'react-router-dom'
 import { useAuth } from '../state/AuthContext.jsx'
 import { useEffect, useState } from 'react'
+import Button from './Button.jsx'
 
 export default function Navbar() {
   const { auth, logout, ui } = useAuth()
@@ -59,9 +60,9 @@ export default function Navbar() {
         <div className={`auth ${open ? 'open' : ''}`}>
           {auth.user ? (
             <>
-              <button className="btn theme-toggle" aria-label="Toggle theme" onClick={() => setTheme(t => t === 'dark' ? 'light' : 'dark')}>
+              <Button className="theme-toggle" aria-label="Toggle theme" onClick={() => setTheme(t => t === 'dark' ? 'light' : 'dark')}>
                 {theme === 'dark' ? '☀️' : '🌙'}
-              </button>
+              </Button>
               <button
                 className="bell"
                 aria-label="Notifications"
@@ -78,9 +79,9 @@ export default function Navbar() {
                   <div className="notif-head">
                     <strong>Notifications</strong>
                     {ui.unread > 0 && (
-                      <button className="btn" onClick={() => ui.markAllRead()}>
+                      <Button onClick={() => ui.markAllRead()}>
                         Mark all read
-                      </button>
+                      </Button>
                     )}
                   </div>
                   <div className="notif-list">
@@ -110,21 +111,21 @@ export default function Navbar() {
                   <span className="nav-avatar nav-fallback">{(auth.user.name || 'U').slice(0, 1).toUpperCase()}</span>
                 )}
               </Link>
-              <button className="btn" onClick={onLogout}>
+              <Button onClick={onLogout}>
                 Logout
-              </button>
+              </Button>
             </>
           ) : (
             <>
-              <button className="btn theme-toggle" aria-label="Toggle theme" onClick={() => setTheme(t => t === 'dark' ? 'light' : 'dark')}>
+              <Button className="theme-toggle" aria-label="Toggle theme" onClick={() => setTheme(t => t === 'dark' ? 'light' : 'dark')}>
                 {theme === 'dark' ? '☀️' : '🌙'}
-              </button>
-              <Link className="btn" to="/login">
+              </Button>
+              <Button as={Link} to="/login">
                 Login
-              </Link>
-              <Link className="btn btn-primary" to="/register">
+              </Button>
+              <Button as={Link} variant="primary" to="/register">
                 Sign Up
-              </Link>
+              </Button>
             </>
           )}
         </div>

--- a/client/src/components/Subnav.jsx
+++ b/client/src/components/Subnav.jsx
@@ -1,4 +1,5 @@
 import { useLocation, useNavigate, Link } from 'react-router-dom'
+import Button from './Button.jsx'
 
 export default function Subnav() {
   const loc = useLocation()
@@ -28,8 +29,8 @@ export default function Subnav() {
     <div className="subnav">
       <div className="container subnav-inner">
         <div style={{ display:'flex', gap:8, alignItems:'center' }}>
-          <button className="btn back-btn" onClick={goBack} aria-label="Go back">← Back</button>
-          <button className="btn" onClick={goForward} aria-label="Go forward">Forward →</button>
+          <Button className="back-btn" onClick={goBack} aria-label="Go back">← Back</Button>
+          <Button onClick={goForward} aria-label="Go forward">Forward →</Button>
         </div>
         <nav className="crumbs" aria-label="Breadcrumb">
           {items.map((it, idx) => (

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -37,11 +37,6 @@ a { color: var(--text); text-decoration: none }
 .notif-content { display:flex; flex-direction:column; gap:var(--space-xxs); flex:1 }
 .notif-thumb { width:var(--space-3xl); height:var(--space-36); border-radius:var(--space-6); border:var(--space-1) solid var(--border); object-fit:cover }
 
-.btn { background: #1b1f2a; border: var(--space-1) solid var(--border); color: var(--text); padding: var(--space-10) var(--space-md); border-radius: var(--space-12); transition: filter .2s }
-.btn-primary { background: var(--primary); border-color: var(--primary); color:#fff }
-.btn:focus { outline: none }
-.btn:hover { filter: brightness(1.1) }
-.btn.loading, .btn:disabled { opacity:.7; cursor:not-allowed }
 
 .page { padding: var(--space-lg) 0 }
 .page-head { display: flex; align-items: center; justify-content: space-between }

--- a/client/src/pages/Admin.jsx
+++ b/client/src/pages/Admin.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useAuth } from '../state/AuthContext.jsx'
+import Button from '../components/Button.jsx'
 
 export default function Admin() {
   const { request, ui } = useAuth()
@@ -124,8 +125,8 @@ export default function Admin() {
                       <option value="author">author</option>
                       <option value="admin">admin</option>
                     </select>
-                    <button className="btn" onClick={async()=>{ await request(`/admin/users/${u.id}/ban`, { method:'PUT', body: JSON.stringify({ banned: !u.is_banned }) }); load() }}>{u.is_banned?'Unban':'Ban'}</button>
-                    <button className="btn" onClick={async()=>{ if (confirm('Delete user account? This cannot be undone.')) { await request(`/admin/users/${u.id}`, { method:'DELETE' }); load() } }}>Delete</button>
+                    <Button onClick={async()=>{ await request(`/admin/users/${u.id}/ban`, { method:'PUT', body: JSON.stringify({ banned: !u.is_banned }) }); load() }}>{u.is_banned?'Unban':'Ban'}</Button>
+                    <Button onClick={async()=>{ if (confirm('Delete user account? This cannot be undone.')) { await request(`/admin/users/${u.id}`, { method:'DELETE' }); load() } }}>Delete</Button>
                   </td>
                 </tr>
               ))}
@@ -154,9 +155,9 @@ export default function Admin() {
                     </Link>
                   </td>
                   <td style={{display:'flex', gap:8}}>
-                    <button className="btn btn-primary" onClick={() => approve(a.id)}>Approve</button>
-                    <button className="btn" onClick={() => reject(a.id)}>Reject</button>
-                    <button className="btn" onClick={() => deleteArticle(a.id)}>Delete</button>
+                    <Button variant="primary" onClick={() => approve(a.id)}>Approve</Button>
+                    <Button onClick={() => reject(a.id)}>Reject</Button>
+                    <Button onClick={() => deleteArticle(a.id)}>Delete</Button>
                   </td>
                 </tr>
               ))}
@@ -169,12 +170,12 @@ export default function Admin() {
       <section className="section-card">
         <h3>Categories</h3>
         <div style={{ display:'flex', justifyContent:'flex-end', marginBottom:8 }}>
-          <Link className="btn" to="/admin/categories">Open full page</Link>
+          <Button as={Link} to="/admin/categories">Open full page</Button>
         </div>
         <div className="form" style={{marginBottom:12}}>
           <input placeholder="Name" value={catName} onChange={(e) => setCatName(e.target.value)} />
           <input placeholder="Slug (optional)" value={catSlug} onChange={(e) => setCatSlug(e.target.value)} />
-          <button className="btn btn-primary" onClick={addCategory}>Add</button>
+          <Button variant="primary" onClick={addCategory}>Add</Button>
         </div>
         <table className="table">
           <thead><tr><th>Name</th><th>Slug</th><th>Actions</th></tr></thead>
@@ -184,15 +185,15 @@ export default function Admin() {
                 <td>{c.name}</td>
                 <td>{c.slug}</td>
                 <td>
-                  <button className="btn" onClick={() => {
+                  <Button onClick={() => {
                     const name = prompt('Rename category', c.name)
                     if (name && name !== c.name) updateCategory(c.id, { name })
-                  }}>Rename</button>
-                  <button className="btn" onClick={() => {
+                  }}>Rename</Button>
+                  <Button onClick={() => {
                     const slug = prompt('Update slug', c.slug)
                     if (slug && slug !== c.slug) updateCategory(c.id, { slug })
-                  }}>Slug</button>
-                  <button className="btn" onClick={() => { if (confirm('Delete category?')) deleteCategory(c.id) }}>Delete</button>
+                  }}>Slug</Button>
+                  <Button onClick={() => { if (confirm('Delete category?')) deleteCategory(c.id) }}>Delete</Button>
                 </td>
               </tr>
             ))}
@@ -213,8 +214,8 @@ export default function Admin() {
               <td>{r.payload?.email || '-'}</td>
               <td>{new Date(r.created_at).toLocaleString()}</td>
               <td style={{display:'flex', gap:8}}>
-                <button className="btn btn-primary" onClick={async()=>{ await request(`/admin/author-requests/${r.id}/approve`, { method:'POST' }); load() }}>Approve</button>
-                <button className="btn" onClick={async()=>{ const reason = prompt('Reason? (optional)')||''; await request(`/admin/author-requests/${r.id}/reject`, { method:'POST', body: JSON.stringify({ reason }) }); load() }}>Reject</button>
+                <Button variant="primary" onClick={async()=>{ await request(`/admin/author-requests/${r.id}/approve`, { method:'POST' }); load() }}>Approve</Button>
+                <Button onClick={async()=>{ const reason = prompt('Reason? (optional)')||''; await request(`/admin/author-requests/${r.id}/reject`, { method:'POST', body: JSON.stringify({ reason }) }); load() }}>Reject</Button>
               </td>
             </tr>
           ))}
@@ -237,15 +238,15 @@ export default function Admin() {
               <td>{new Date(r.created_at).toLocaleString()}</td>
               <td>
                 <span className="chip">{r.target_type}</span>
-                {r.target_type==='post' && <a className="btn btn-link" href={`/article/${r.target_id}`} target="_blank" rel="noreferrer">Open</a>}
+                {r.target_type==='post' && <Button as="a" className="btn-link" href={`/article/${r.target_id}`} target="_blank" rel="noreferrer">Open</Button>}
               </td>
               <td>{r.reporter?.name || r.reporter_id}</td>
               <td style={{maxWidth:420, whiteSpace:'pre-wrap'}}>{r.reason}</td>
               <td>{r.status}</td>
               <td style={{display:'flex', gap:8}}>
-                <button className="btn" onClick={()=>updateReport(r.id, { status: 'reviewed' })}>Review</button>
-                <button className="btn" onClick={()=>updateReport(r.id, { status: 'dismissed' })}>Dismiss</button>
-                <button className="btn" onClick={()=>updateReport(r.id, { status: 'actioned' })}>Actioned</button>
+                <Button onClick={()=>updateReport(r.id, { status: 'reviewed' })}>Review</Button>
+                <Button onClick={()=>updateReport(r.id, { status: 'dismissed' })}>Dismiss</Button>
+                <Button onClick={()=>updateReport(r.id, { status: 'actioned' })}>Actioned</Button>
               </td>
             </tr>
           ))}

--- a/client/src/pages/AdminCategories.jsx
+++ b/client/src/pages/AdminCategories.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useAuth } from '../state/AuthContext.jsx'
+import Button from '../components/Button.jsx'
 
 export default function AdminCategories() {
   const { request, ui } = useAuth()
@@ -45,7 +46,7 @@ export default function AdminCategories() {
           <input placeholder="Name" value={name} onChange={(e)=>setName(e.target.value)} />
           <input placeholder="Slug (optional)" value={slug} onChange={(e)=>setSlug(e.target.value)} />
           <div style={{display:'flex', justifyContent:'flex-end'}}>
-            <button className="btn btn-primary" onClick={add}>Create</button>
+            <Button variant="primary" onClick={add}>Create</Button>
           </div>
         </div>
       </section>
@@ -60,15 +61,15 @@ export default function AdminCategories() {
                   <td>{c.name}</td>
                   <td>{c.slug}</td>
                   <td>
-                    <button className="btn" onClick={() => {
+                    <Button onClick={() => {
                       const v = prompt('Rename category', c.name)
                       if (v && v !== c.name) update(c.id, { name: v })
-                    }}>Rename</button>
-                    <button className="btn" onClick={() => {
+                    }}>Rename</Button>
+                    <Button onClick={() => {
                       const v = prompt('Update slug', c.slug)
                       if (v && v !== c.slug) update(c.id, { slug: v })
-                    }}>Slug</button>
-                    <button className="btn" onClick={() => remove(c.id)}>Delete</button>
+                    }}>Slug</Button>
+                    <Button onClick={() => remove(c.id)}>Delete</Button>
                   </td>
                 </tr>
               ))}

--- a/client/src/pages/Article.jsx
+++ b/client/src/pages/Article.jsx
@@ -9,6 +9,7 @@ import rehypeSanitize, { defaultSchema } from 'rehype-sanitize'
 import rehypeHighlight from 'rehype-highlight'
 import Comments from '../components/Comments.jsx'
 import ArticleCard from '../components/ArticleCard.jsx'
+import Button from '../components/Button.jsx'
 
 export default function Article() {
   const { id, slug } = useParams()
@@ -193,22 +194,22 @@ export default function Article() {
           <div className="muted">{readingMinutes} min read</div>
           <p className="muted">{new Date(article.created_at).toLocaleString()} • {article.like_count} likes</p>
         </div>
-        <a className="btn" href={`/author/${article.author_id}`}>View Author</a>
+        <Button as="a" href={`/author/${article.author_id}`}>View Author</Button>
       </div>
       <div style={{ display: 'flex', gap: 8, marginBottom: 16 }}>
-        <button className="btn btn-primary" onClick={like} disabled={liked}>{liked ? 'Liked' : 'Like'}</button>
-        <button className="btn" onClick={follow}>Follow Author</button>
-        <button className="btn" onClick={toggleSave}>{saved ? 'Saved' : 'Save'}</button>
-        <button className="btn" onClick={share}>Share</button>
-        <button className="btn" onClick={copyLink}>Copy Link</button>
-        <button className="btn" onClick={async()=>{
+        <Button variant="primary" onClick={like} disabled={liked}>{liked ? 'Liked' : 'Like'}</Button>
+        <Button onClick={follow}>Follow Author</Button>
+        <Button onClick={toggleSave}>{saved ? 'Saved' : 'Save'}</Button>
+        <Button onClick={share}>Share</Button>
+        <Button onClick={copyLink}>Copy Link</Button>
+        <Button onClick={async()=>{
           try {
             const reason = prompt('Why are you reporting this article?') || ''
             if (!reason.trim()) return
             await request('/reports', { method:'POST', body: JSON.stringify({ target_type:'post', target_id: article.id, reason }) })
             ui.notify('Report submitted. Thank you.', 'info')
           } catch {}
-        }}>Report</button>
+        }}>Report</Button>
       </div>
       <div className="markdown-layout" style={{ display: 'grid', gridTemplateColumns: toc.length ? 'minmax(0,1fr) 280px' : '1fr', gap: 'var(--space-lg)' }}>
         <div className="markdown">

--- a/client/src/pages/Author.jsx
+++ b/client/src/pages/Author.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import { useAuth } from '../state/AuthContext.jsx'
 import ArticleCard from '../components/ArticleCard.jsx'
+import Button from '../components/Button.jsx'
 
 export default function Author() {
   const { id } = useParams()
@@ -68,9 +69,9 @@ export default function Author() {
         <div style={{ marginLeft: 'auto' }}>
           {auth.user && auth.user.id !== id && (
             followed ? (
-              <button className="btn" onClick={unfollow}>Unfollow</button>
+              <Button onClick={unfollow}>Unfollow</Button>
             ) : (
-              <button className="btn btn-primary" onClick={follow}>Follow</button>
+              <Button variant="primary" onClick={follow}>Follow</Button>
             )
           )}
         </div>
@@ -83,9 +84,9 @@ export default function Author() {
             {articles.map((a) => <ArticleCard article={a} key={a.id} />)}
           </div>
           <div style={{ display: 'flex', gap: 8, justifyContent: 'center', marginTop: 16 }}>
-            <button className="btn" disabled={page <= 1} onClick={() => setPage((p) => Math.max(1, p - 1))}>Prev</button>
+            <Button disabled={page <= 1} onClick={() => setPage((p) => Math.max(1, p - 1))}>Prev</Button>
             <span className="muted">Page {pageInfo?.page || page} / {pageInfo?.totalPages || '?'}</span>
-            <button className="btn" disabled={pageInfo && page >= pageInfo.totalPages} onClick={() => setPage((p) => p + 1)}>Next</button>
+            <Button disabled={pageInfo && page >= pageInfo.totalPages} onClick={() => setPage((p) => p + 1)}>Next</Button>
           </div>
         </>
       )}

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useAuth } from '../state/AuthContext.jsx'
+import Button from '../components/Button.jsx'
 
 export default function Dashboard() {
   const { request, auth } = useAuth()
@@ -21,7 +22,7 @@ export default function Dashboard() {
     <div className="container page">
       <div className="page-head">
         <h2>Your Articles</h2>
-        <Link className="btn btn-primary" to="/editor">New Article</Link>
+        <Button as={Link} variant="primary" to="/editor">New Article</Button>
       </div>
       <div className="tabs" role="tablist" aria-label="Article status tabs" style={{ marginTop: 8 }}>
         {['all','draft','pending','published'].map((s) => (
@@ -42,18 +43,18 @@ export default function Dashboard() {
                 <td><span className={`badge ${a.status}`}>{a.status==='pending'?'in review':a.status}</span></td>
                 <td>{a.like_count}</td>
                 <td>
-                  <Link className="btn" to={`/editor/${a.id}`}>Edit</Link>
+                  <Button as={Link} to={`/editor/${a.id}`}>Edit</Button>
                   {a.status==='draft' && (
-                    <button className="btn btn-primary" style={{marginLeft:8}} onClick={async () => {
+                    <Button variant="primary" style={{marginLeft:8}} onClick={async () => {
                       await request(`/articles/${a.id}`, { method: 'PUT', body: JSON.stringify({ status: 'pending' }) })
                       await load()
-                    }}>Submit for review</button>
+                    }}>Submit for review</Button>
                   )}
-                  <button className="btn" style={{marginLeft:8}} onClick={async () => {
+                  <Button style={{marginLeft:8}} onClick={async () => {
                     if (!confirm('Delete this article? This cannot be undone.')) return
                     await request(`/articles/${a.id}`, { method: 'DELETE' })
                     load()
-                  }}>Delete</button>
+                  }}>Delete</Button>
                 </td>
               </tr>
             ))}

--- a/client/src/pages/Editor.jsx
+++ b/client/src/pages/Editor.jsx
@@ -4,6 +4,7 @@ import { useAuth } from '../state/AuthContext.jsx'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import rehypeSanitize from 'rehype-sanitize'
+import Button from '../components/Button.jsx'
 
 export default function Editor() {
   const { request, auth, ui } = useAuth()
@@ -286,23 +287,23 @@ export default function Editor() {
       <form onSubmit={onSubmit} className="form">
         <input placeholder="Title" value={form.title} onChange={(e) => setForm({ ...form, title: e.target.value })} />
         <div className="editor-toolbar">
-          <button type="button" className="btn" onClick={() => wrapSelection('**','**')}>Bold</button>
-          <button type="button" className="btn" onClick={() => wrapSelection('_','_')}>Italic</button>
-          <button type="button" className="btn" onClick={() => wrapSelection('<u>','</u>')}>Underline</button>
-          <button type="button" className="btn" onClick={insertLink}>Link</button>
-          <button type="button" className="btn" onClick={() => insertLine('# ')}>H1</button>
-          <button type="button" className="btn" onClick={() => insertLine('## ')}>H2</button>
-          <button type="button" className="btn" onClick={() => insertLine('### ')}>H3</button>
-          <button type="button" className="btn" onClick={() => insertLine('> ')}>Quote</button>
-          <button type="button" className="btn" onClick={() => wrapSelection('`','`')}>Code</button>
-          <button type="button" className="btn" onClick={() => insertLine('- ')}>Bulleted</button>
-          <button type="button" className="btn" onClick={() => insertLine('1. ')}>Ordered</button>
-          <button type="button" className="btn" onClick={() => insertLine('- [ ] ')}>Task</button>
-          <button type="button" className="btn" onClick={insertHr}>HR</button>
-          <button type="button" className="btn" onClick={insertCodeBlock}>Code Block</button>
-          <button type="button" className="btn" onClick={clearFormatting}>Clear</button>
+          <Button type="button" onClick={() => wrapSelection('**','**')}>Bold</Button>
+          <Button type="button" onClick={() => wrapSelection('_','_')}>Italic</Button>
+          <Button type="button" onClick={() => wrapSelection('<u>','</u>')}>Underline</Button>
+          <Button type="button" onClick={insertLink}>Link</Button>
+          <Button type="button" onClick={() => insertLine('# ')}>H1</Button>
+          <Button type="button" onClick={() => insertLine('## ')}>H2</Button>
+          <Button type="button" onClick={() => insertLine('### ')}>H3</Button>
+          <Button type="button" onClick={() => insertLine('> ')}>Quote</Button>
+          <Button type="button" onClick={() => wrapSelection('`','`')}>Code</Button>
+          <Button type="button" onClick={() => insertLine('- ')}>Bulleted</Button>
+          <Button type="button" onClick={() => insertLine('1. ')}>Ordered</Button>
+          <Button type="button" onClick={() => insertLine('- [ ] ')}>Task</Button>
+          <Button type="button" onClick={insertHr}>HR</Button>
+          <Button type="button" onClick={insertCodeBlock}>Code Block</Button>
+          <Button type="button" onClick={clearFormatting}>Clear</Button>
           <input id="media-input" type="file" accept="image/png,image/jpeg,image/webp" multiple hidden onChange={handleMediaSelect} />
-          <button type="button" className="btn btn-primary" onClick={() => document.getElementById('media-input').click()}>Add Image</button>
+          <Button type="button" variant="primary" onClick={() => document.getElementById('media-input').click()}>Add Image</Button>
         </div>
         <div>
           <label>Thumbnail image</label>
@@ -361,7 +362,7 @@ export default function Editor() {
         {error && <p className="error">{error}</p>}
         {articleId && (
           <div style={{ display:'flex', gap:'var(--space-sm)', alignItems:'center', margin:'var(--space-sm) 0' }}>
-            <button className="btn" type="button" onClick={async()=>{
+            <Button type="button" onClick={async()=>{
               try {
                 const r = await request(`/articles/${articleId}/preview`, { method:'POST' })
                 const url = r?.url || (r?.token ? `/p/${r.token}` : '')
@@ -370,13 +371,13 @@ export default function Editor() {
                   ui.notify('Preview link copied to clipboard', 'success')
                 }
               } catch {}
-            }}>Get Preview Link</button>
+            }}>Get Preview Link</Button>
             <span className="muted" style={{ fontSize: '.85rem' }}>Share this link to preview your draft without login.</span>
           </div>
         )}
-        <button className={`btn btn-primary ${saving ? 'loading' : ''}`} type="submit" disabled={saving}>
+        <Button variant="primary" type="submit" loading={saving}>
           {saving ? 'Saving…' : (form.status === 'pending' && auth.user?.role !== 'admin' ? 'Submit for review' : 'Save')}
-        </button>
+        </Button>
       </form>
       <aside className="editor-preview">
         <div className="card">
@@ -400,7 +401,7 @@ export default function Editor() {
               {revisions.map((r) => (
                 <li key={r.id} style={{display:'flex', justifyContent:'space-between', alignItems:'center'}}>
                   <span>{new Date(r.created_at).toLocaleString()} — {r.title}</span>
-                  <button className="btn" onClick={async ()=>{ try { const a = await request(`/articles/${articleId}/revisions/${r.id}/restore`, { method:'POST' }); setForm({ ...form, title: a.title, content: a.content }); ui.notify('Revision restored', 'success'); request(`/articles/${articleId}/revisions`, { noGlobalLoading: true }).then(setRevisions).catch(()=>{}) } catch{} }}>Restore</button>
+                  <Button onClick={async ()=>{ try { const a = await request(`/articles/${articleId}/revisions/${r.id}/restore`, { method:'POST' }); setForm({ ...form, title: a.title, content: a.content }); ui.notify('Revision restored', 'success'); request(`/articles/${articleId}/revisions`, { noGlobalLoading: true }).then(setRevisions).catch(()=>{}) } catch{} }}>Restore</Button>
                 </li>
               ))}
             </ul>

--- a/client/src/pages/Feed.jsx
+++ b/client/src/pages/Feed.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useAuth } from '../state/AuthContext.jsx'
 import ArticleCard from '../components/ArticleCard.jsx'
+import Button from '../components/Button.jsx'
 
 export default function Feed() {
   const { request } = useAuth()
@@ -37,9 +38,9 @@ export default function Feed() {
             {items.map((a) => <ArticleCard article={a} key={a.id} />)}
           </div>
           <div style={{ display: 'flex', gap: 8, justifyContent: 'center', marginTop: 16 }}>
-            <button className="btn" disabled={page <= 1} onClick={() => setPage((p) => Math.max(1, p - 1))}>Prev</button>
+            <Button disabled={page <= 1} onClick={() => setPage((p) => Math.max(1, p - 1))}>Prev</Button>
             <span className="muted">Page {pageInfo?.page || page} / {pageInfo?.totalPages || '?'}</span>
-            <button className="btn" disabled={pageInfo && page >= pageInfo.totalPages} onClick={() => setPage((p) => p + 1)}>Next</button>
+            <Button disabled={pageInfo && page >= pageInfo.totalPages} onClick={() => setPage((p) => p + 1)}>Next</Button>
           </div>
         </>
       )}

--- a/client/src/pages/ForgotPassword.jsx
+++ b/client/src/pages/ForgotPassword.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useAuth } from '../state/AuthContext.jsx'
+import Button from '../components/Button.jsx'
 
 export default function ForgotPassword() {
   const { request, ui } = useAuth()
@@ -28,7 +29,7 @@ export default function ForgotPassword() {
           <form className="form" onSubmit={submit}>
             <input type="email" placeholder="Email" value={email} onChange={(e)=>setEmail(e.target.value)} required />
             {error && <p className="error">{error}</p>}
-            <button className="btn btn-primary" type="submit" disabled={sent}>{sent ? 'Sent' : 'Send reset link'}</button>
+            <Button type="submit" variant="primary" disabled={sent}>{sent ? 'Sent' : 'Send reset link'}</Button>
           </form>
         </div>
       </div>

--- a/client/src/pages/Home.jsx
+++ b/client/src/pages/Home.jsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import useMeta from '../utils/useMeta.js'
 import { useAuth } from '../state/AuthContext.jsx'
 import ArticleCard from '../components/ArticleCard.jsx'
+import Button from '../components/Button.jsx'
 
 export default function Home() {
   const { request } = useAuth()
@@ -154,8 +155,8 @@ export default function Home() {
             <h1 className="hero-title">Read. Write. Discover.</h1>
             <p className="hero-sub">Fresh articles from authors you follow and love.</p>
           <div className="hero-cta">
-            <a className="btn btn-primary" href="#feed">Explore Articles</a>
-            <a className="btn" href="/register">Join Free</a>
+            <Button as="a" variant="primary" href="#feed">Explore Articles</Button>
+            <Button as="a" href="/register">Join Free</Button>
           </div>
             <form ref={heroSearchRef} className="hero-search" onSubmit={onHeroSearch} role="search" aria-label="Search articles">
               <input
@@ -188,7 +189,7 @@ export default function Home() {
                   else if (e.key === 'Escape') { setShowSuggest(false) }
                 }}
               />
-              <button className="btn btn-primary" type="submit">Search</button>
+              <Button variant="primary" type="submit">Search</Button>
               {showSuggest && suggestions.length > 0 && (
                 <div className="suggest">
                   {suggestions.map((s, i) => (
@@ -250,7 +251,7 @@ export default function Home() {
             <option value={c.slug} key={c.id}>{c.name}</option>
           ))}
         </select>
-        <button className="btn" onClick={() => { setPage(1); fetchData(true) }}>Apply</button>
+        <Button onClick={() => { setPage(1); fetchData(true) }}>Apply</Button>
       </div>
       {loading ? (
         <div className="grid" id="feed">
@@ -278,9 +279,9 @@ export default function Home() {
                 <span className="muted">{pageInfo && page >= (pageInfo.totalPages || 1) ? 'No more results' : ''}</span>
               )
             ) : (
-              <button className="btn" disabled={loadingMore || (pageInfo && page >= (pageInfo.totalPages || 1))} onClick={() => setPage((p) => p + 1)}>
+              <Button disabled={loadingMore || (pageInfo && page >= (pageInfo.totalPages || 1))} onClick={() => setPage((p) => p + 1)}>
                 {loadingMore ? 'Loading…' : 'Load more'}
-              </button>
+              </Button>
             )}
           </div>
         </>

--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { useNavigate, Link } from 'react-router-dom'
 import { useAuth } from '../state/AuthContext.jsx'
+import Button from '../components/Button.jsx'
 
 export default function Login() {
   const { login } = useAuth()
@@ -30,7 +31,7 @@ export default function Login() {
             <input placeholder="Email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} />
             <input placeholder="Password" type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
             {error && <p className="error">{error}</p>}
-            <button className="btn btn-primary" type="submit">Login</button>
+            <Button type="submit" variant="primary">Login</Button>
           </form>
           <p className="muted">No account? <Link to="/register">Sign up</Link></p>
           <p className="muted">Forgot your password? <Link to="/forgot-password">Reset it</Link></p>

--- a/client/src/pages/Profile.jsx
+++ b/client/src/pages/Profile.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState, useMemo } from 'react'
 import { Link } from 'react-router-dom'
 import { useAuth } from '../state/AuthContext.jsx'
+import Button from '../components/Button.jsx'
 
 export default function Profile() {
   const { request, auth, setAuth } = useAuth()
@@ -63,7 +64,7 @@ export default function Profile() {
                   const updated = await request('/me', { method:'PUT', body: JSON.stringify({ avatar_url: data.url, avatar_path: data.path }) })
                   setMe(updated); setAuth({ ...auth, user: { ...auth.user, name: updated.name, avatar_url: updated.avatar_url } }); setSuccess('Avatar updated')
                 }}/>
-                <button className="btn" onClick={()=>fileRef.current?.click()}>Change Avatar</button>
+                <Button onClick={()=>fileRef.current?.click()}>Change Avatar</Button>
               </div>
             </div>
           </div>
@@ -83,9 +84,9 @@ export default function Profile() {
             <h3 style={{marginTop:0}}>Become an Author</h3>
             <p className="muted">Submit an application to publish posts. An admin will review your request.</p>
             <div style={{display:'flex', gap:8}}>
-              <button className="btn btn-primary" onClick={async()=>{
+              <Button variant="primary" onClick={async()=>{
                 try { await request('/me/apply-author', { method: 'POST' }); alert('Application submitted. You will be notified.'); setApplyStatus({ requestedAt: new Date().toISOString() }) } catch{}
-              }}>Apply for author</button>
+              }}>Apply for author</Button>
               {applyStatus?.requestedAt && <span className="muted">Requested: {new Date(applyStatus.requestedAt).toLocaleString()}</span>}
             </div>
           </section>
@@ -217,10 +218,10 @@ export default function Profile() {
             <input placeholder="Name" value={name} onChange={(e)=>setName(e.target.value)} />
             <textarea placeholder="Bio" rows={3} value={bio} onChange={(e)=>setBio(e.target.value)} />
             <div style={{display:'flex', gap:8, justifyContent:'flex-end'}}>
-              <button className="btn btn-primary" onClick={async ()=>{
+              <Button variant="primary" onClick={async ()=>{
                 setError(''); setSuccess('')
                 try { const updated = await request('/me', { method:'PUT', body: JSON.stringify({ name, bio }) }); setMe(updated); setAuth({ ...auth, user: { ...auth.user, name: updated.name } }); setSuccess('Profile saved') } catch(e){ setError(e.message) }
-              }}>Save Changes</button>
+              }}>Save Changes</Button>
             </div>
             {(error || success) && (
               <div style={{display:'flex', gap:8}}>
@@ -237,10 +238,10 @@ export default function Profile() {
             <input placeholder="Current password" type="password" value={pwd.current} onChange={(e)=>setPwd({...pwd, current:e.target.value})} />
             <input placeholder="New password" type="password" value={pwd.next} onChange={(e)=>setPwd({...pwd, next:e.target.value})} />
             <div style={{display:'flex', justifyContent:'flex-end'}}>
-              <button className="btn" onClick={async ()=>{
+              <Button onClick={async ()=>{
                 setError(''); setSuccess('')
                 try { const r = await request('/me/password', { method:'PUT', body: JSON.stringify({ current_password: pwd.current, new_password: pwd.next }) }); if (r?.token) setAuth({ token: r.token, user: auth.user }); setSuccess('Password changed') } catch(e){ setError(e.message) }
-              }}>Update Password</button>
+              }}>Update Password</Button>
             </div>
           </div>
         </section>

--- a/client/src/pages/Register.jsx
+++ b/client/src/pages/Register.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { useNavigate, Link } from 'react-router-dom'
 import { useAuth } from '../state/AuthContext.jsx'
+import Button from '../components/Button.jsx'
 
 export default function Register() {
   const { register } = useAuth()
@@ -32,7 +33,7 @@ export default function Register() {
             <input placeholder="Email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} />
             <input placeholder="Password" type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
             {error && <p className="error">{error}</p>}
-            <button className="btn btn-primary" type="submit">Create account</button>
+            <Button type="submit" variant="primary">Create account</Button>
           </form>
           <p className="muted">Have an account? <Link to="/login">Log in</Link></p>
         </div>

--- a/client/src/pages/ResetPassword.jsx
+++ b/client/src/pages/ResetPassword.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { useAuth } from '../state/AuthContext.jsx'
+import Button from '../components/Button.jsx'
 
 export default function ResetPassword() {
   const { request, ui } = useAuth()
@@ -42,7 +43,7 @@ export default function ResetPassword() {
             <input type="password" placeholder="New password (min 8)" value={password} onChange={(e)=>setPassword(e.target.value)} required />
             <input type="password" placeholder="Confirm password" value={confirm} onChange={(e)=>setConfirm(e.target.value)} required />
             {error && <p className="error">{error}</p>}
-            <button className="btn btn-primary" type="submit" disabled={done}>Reset Password</button>
+            <Button type="submit" variant="primary" disabled={done}>Reset Password</Button>
           </form>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add Button component with variant and size props
- move button styling to a CSS module
- replace legacy `.btn` usage across pages
- document button variants

## Testing
- `npm --prefix client run lint` *(fails: Empty block statement errors in existing files)*
- `npm --prefix client test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bf3e9996648322b9092a58af84495e