### PR TITLE
feat: add theme context and toggling

### DIFF
--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -1,17 +1,16 @@
 import { Link, useNavigate } from 'react-router-dom'
 import { useAuth } from '../state/AuthContext.jsx'
 import { useEffect, useState } from 'react'
+import { useTheme } from '../state/ThemeContext.jsx'
 import Button from './Button.jsx'
 
 export default function Navbar() {
   const { auth, logout, ui } = useAuth()
+  const { theme, toggleTheme } = useTheme()
   const nav = useNavigate()
   const [open, setOpen] = useState(false)
   const [showNotif, setShowNotif] = useState(false)
   const [pfpOk, setPfpOk] = useState(true)
-  const [theme, setTheme] = useState(() => {
-    try { return localStorage.getItem('theme') || 'dark' } catch { return 'dark' }
-  })
 
   const onLogout = () => {
     logout()
@@ -24,12 +23,6 @@ export default function Navbar() {
     const t = setInterval(() => ui.loadNotifications().catch(() => {}), 20000)
     return () => clearInterval(t)
   }, [auth.user])
-
-  useEffect(() => {
-    try { localStorage.setItem('theme', theme) } catch {}
-    const root = document.documentElement
-    root.setAttribute('data-theme', theme)
-  }, [theme])
 
   return (
     <header className="nav">
@@ -60,7 +53,7 @@ export default function Navbar() {
         <div className={`auth ${open ? 'open' : ''}`}>
           {auth.user ? (
             <>
-              <Button className="theme-toggle" aria-label="Toggle theme" onClick={() => setTheme(t => t === 'dark' ? 'light' : 'dark')}>
+              <Button className="theme-toggle" aria-label="Toggle theme" onClick={toggleTheme}>
                 {theme === 'dark' ? '☀️' : '🌙'}
               </Button>
               <button
@@ -117,7 +110,7 @@ export default function Navbar() {
             </>
           ) : (
             <>
-              <Button className="theme-toggle" aria-label="Toggle theme" onClick={() => setTheme(t => t === 'dark' ? 'light' : 'dark')}>
+              <Button className="theme-toggle" aria-label="Toggle theme" onClick={toggleTheme}>
                 {theme === 'dark' ? '☀️' : '🌙'}
               </Button>
               <Button as={Link} to="/login">

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,6 +1,7 @@
 @import "./styles/tokens.css";
 
 :root { --bg: #0b0c10; --card: #111318; --text: #e5e7eb; --muted: #9aa3b2; --primary: #6366f1; --border: #1f2530; --accent: #10b981; }
+[data-theme='light'] { --bg: #f9fafb; --card: #ffffff; --text: #111827; --muted: #4b5563; --primary: #6366f1; --border: #e5e7eb; --accent: #10b981; }
 * { box-sizing: border-box }
 html, body, #root { height: 100% }
 body { margin: 0; font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif; background: var(--bg); color: var(--text); }

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -3,11 +3,14 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.jsx'
 import { AuthProvider } from './state/AuthContext.jsx'
+import { ThemeProvider } from './state/ThemeContext.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <AuthProvider>
-      <App />
-    </AuthProvider>
+    <ThemeProvider>
+      <AuthProvider>
+        <App />
+      </AuthProvider>
+    </ThemeProvider>
   </StrictMode>,
 )

--- a/client/src/state/ThemeContext.jsx
+++ b/client/src/state/ThemeContext.jsx
@@ -1,0 +1,31 @@
+import { createContext, useContext, useEffect, useMemo, useState } from 'react'
+
+const ThemeContext = createContext(null)
+
+export function ThemeProvider({ children }) {
+  const [theme, setTheme] = useState(() => {
+    try {
+      return localStorage.getItem('theme') || 'dark'
+    } catch {
+      return 'dark'
+    }
+  })
+
+  useEffect(() => {
+    try { localStorage.setItem('theme', theme) } catch {}
+    document.documentElement.setAttribute('data-theme', theme)
+  }, [theme])
+
+  const toggleTheme = () => setTheme(t => t === 'dark' ? 'light' : 'dark')
+
+  const value = useMemo(() => ({ theme, toggleTheme }), [theme])
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
+}
+
+export function useTheme() {
+  const ctx = useContext(ThemeContext)
+  if (!ctx) throw new Error('useTheme must be used within ThemeProvider')
+  return ctx
+}
+


### PR DESCRIPTION
## Summary
- add ThemeContext to manage color theme
- wire ThemeProvider and update Navbar toggle
- add light theme CSS variables

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: eslint errors)


------
https://chatgpt.com/codex/tasks/task_e_68bf415b53c08322ae093785eeda7b75