### PR TITLE
Refactor admin panel layout and fix footer

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -45,37 +45,41 @@ function GlobalUI() {
 function App() {
   return (
     <BrowserRouter>
-      <Navbar />
-      <Subnav />
-      <GlobalUI />
-      <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/login" element={<Login />} />
-        <Route path="/forgot-password" element={<ForgotPassword />} />
-        <Route path="/reset-password" element={<ResetPassword />} />
-        <Route path="/register" element={<Register />} />
-        <Route path="/categories" element={<Categories />} />
-        <Route path="/category/:slug" element={<Category />} />
-        <Route path="/article/:id" element={<Article />} />
-        <Route path="/a/:slug" element={<Article />} />
-        <Route path="/p/:token" element={<Preview />} />
-        <Route path="/author/:id" element={<Author />} />
-        <Route element={<ProtectedRoute roles={["reader","author","admin"]} />}> 
-          <Route path="/feed" element={<Feed />} />
-        </Route>
-        <Route element={<ProtectedRoute roles={["author","admin"]} />}> 
-          <Route path="/dashboard" element={<Dashboard />} />
-          <Route path="/editor/:id?" element={<Editor />} />
-        </Route>
-        <Route element={<ProtectedRoute roles={["reader","author","admin"]} />}> 
-          <Route path="/profile" element={<Profile />} />
-        </Route>
-        <Route element={<ProtectedRoute roles={["admin"]} />}> 
-          <Route path="/admin" element={<Admin />} />
-          <Route path="/admin/categories" element={<AdminCategories />} />
-        </Route>
-      </Routes>
-      <Footer />
+      <div className="app-shell">
+        <Navbar />
+        <Subnav />
+        <GlobalUI />
+        <main className="app-main">
+          <Routes>
+            <Route path="/" element={<Home />} />
+            <Route path="/login" element={<Login />} />
+            <Route path="/forgot-password" element={<ForgotPassword />} />
+            <Route path="/reset-password" element={<ResetPassword />} />
+            <Route path="/register" element={<Register />} />
+            <Route path="/categories" element={<Categories />} />
+            <Route path="/category/:slug" element={<Category />} />
+            <Route path="/article/:id" element={<Article />} />
+            <Route path="/a/:slug" element={<Article />} />
+            <Route path="/p/:token" element={<Preview />} />
+            <Route path="/author/:id" element={<Author />} />
+            <Route element={<ProtectedRoute roles={["reader","author","admin"]} />}> 
+              <Route path="/feed" element={<Feed />} />
+            </Route>
+            <Route element={<ProtectedRoute roles={["author","admin"]} />}> 
+              <Route path="/dashboard" element={<Dashboard />} />
+              <Route path="/editor/:id?" element={<Editor />} />
+            </Route>
+            <Route element={<ProtectedRoute roles={["reader","author","admin"]} />}> 
+              <Route path="/profile" element={<Profile />} />
+            </Route>
+            <Route element={<ProtectedRoute roles={["admin"]} />}> 
+              <Route path="/admin" element={<Admin />} />
+              <Route path="/admin/categories" element={<AdminCategories />} />
+            </Route>
+          </Routes>
+        </main>
+        <Footer />
+      </div>
     </BrowserRouter>
   )
 }

--- a/client/src/components/AdminLayout.jsx
+++ b/client/src/components/AdminLayout.jsx
@@ -1,0 +1,36 @@
+import { Link } from 'react-router-dom'
+
+export default function AdminLayout({ tab, setTab, pendingCount = 0, appCount = 0, reportCount = 0, children }) {
+  return (
+    <div className="container page">
+      <h2>Admin Panel</h2>
+      <div className="admin-layout">
+        <aside className="admin-sidebar">
+          <nav className="admin-nav" aria-label="Admin sections">
+            <button className={`admin-link ${tab === 'dashboard' ? 'active' : ''}`} onClick={() => setTab('dashboard')}>Dashboard</button>
+            <button className={`admin-link ${tab === 'users' ? 'active' : ''}`} onClick={() => setTab('users')}>Users</button>
+            <button className={`admin-link ${tab === 'pending' ? 'active' : ''}`} onClick={() => setTab('pending')}>
+              <span>Pending Posts</span>
+              {pendingCount ? <span className="count">{pendingCount}</span> : null}
+            </button>
+            <button className={`admin-link ${tab === 'categories' ? 'active' : ''}`} onClick={() => setTab('categories')}>Categories</button>
+            <button className={`admin-link ${tab === 'applications' ? 'active' : ''}`} onClick={() => setTab('applications')}>
+              <span>Applications</span>
+              {appCount ? <span className="count">{appCount}</span> : null}
+            </button>
+            <button className={`admin-link ${tab === 'reports' ? 'active' : ''}`} onClick={() => setTab('reports')}>
+              <span>Reports</span>
+              {reportCount ? <span className="count">{reportCount}</span> : null}
+            </button>
+            <div className="muted" style={{ margin: 'var(--space-12) var(--space-xs) var(--space-xs)', fontSize: '.85rem' }}>Quick links</div>
+            <Link className="admin-link" to="/editor">New Post</Link>
+            <Link className="admin-link" to="/dashboard">Author Dashboard</Link>
+            <Link className="admin-link" to="/profile">Profile</Link>
+            <Link className="admin-link" to="/">Home</Link>
+          </nav>
+        </aside>
+        <main className="admin-content">{children}</main>
+      </div>
+    </div>
+  )
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -7,6 +7,8 @@ html, body, #root { height: 100% }
 body { margin: 0; font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif; background: var(--bg); color: var(--text); }
 a { color: var(--text); text-decoration: none }
 .container { width:100%; max-width:1280px; margin: 0 auto; padding: 0 var(--space-md) }
+.app-shell { min-height:100vh; display:flex; flex-direction:column }
+.app-main { flex:1 }
 @media (min-width: 1536px) { .container { max-width: 1440px; } }
 @media (min-width: 1920px) { .container { max-width: 1600px; } }
 
@@ -342,13 +344,13 @@ textarea[placeholder^="Write your content"] { font-family: ui-monospace, SFMono-
 .admin-layout { display:grid; grid-template-columns: 220px 1fr; gap:var(--space-md) }
 .admin-sidebar { background: var(--card); border:var(--space-1) solid var(--border); border-radius:var(--space-12); padding:var(--space-12); height:fit-content; position:sticky; top:112px }
 .admin-nav { display:flex; flex-direction:column; gap:var(--space-sm) }
-.admin-link { background:#0f1320; border:var(--space-1) solid var(--border); color:var(--text); padding:var(--space-sm) var(--space-12); border-radius:var(--space-sm); text-align:left; cursor:pointer }
+.admin-link { background:#0f1320; border:var(--space-1) solid var(--border); color:var(--text); padding:var(--space-sm) var(--space-12); border-radius:var(--space-sm); text-align:left; cursor:pointer; display:flex; align-items:center; justify-content:space-between }
 .admin-link.active { background:#141a2a }
 .admin-link:hover { filter: brightness(1.04) }
 [data-theme='light'] .admin-sidebar { background:#fff }
 [data-theme='light'] .admin-link { background:#f3f4f6 }
 [data-theme='light'] .admin-link.active { background:#e5e7eb }
-.admin-link:hover { filter: brightness(1.04) }
+.admin-link .count { background: var(--primary); color: #fff; border-radius: var(--space-sm); padding: 0 var(--space-6); font-size: .75rem }
 @media (max-width: 900px) {
   .admin-layout { grid-template-columns: 1fr }
   .admin-sidebar { position:static }

--- a/client/src/pages/Admin.jsx
+++ b/client/src/pages/Admin.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useAuth } from '../state/AuthContext.jsx'
 import Button from '../components/Button.jsx'
+import AdminLayout from '../components/AdminLayout.jsx'
 
 export default function Admin() {
   const { request, ui } = useAuth()
@@ -256,34 +257,20 @@ export default function Admin() {
   )
 
   return (
-    <div className="container page">
-      <h2>Admin Panel</h2>
+    <AdminLayout
+      tab={tab}
+      setTab={setTab}
+      pendingCount={pending.length}
+      appCount={apps.length}
+      reportCount={reports.filter(r=>r.status==='open').length}
+    >
       {error && <p className="error">{error}</p>}
-      <div className="admin-layout">
-        <aside className="admin-sidebar">
-        <nav className="admin-nav" aria-label="Admin sections">
-            <button className={`admin-link ${tab==='dashboard'?'active':''}`} onClick={()=>setTab('dashboard')}>Dashboard</button>
-            <button className={`admin-link ${tab==='users'?'active':''}`} onClick={()=>setTab('users')}>Users</button>
-            <button className={`admin-link ${tab==='pending'?'active':''}`} onClick={()=>setTab('pending')}>Pending Posts {pending.length?`(${pending.length})`:''}</button>
-            <button className={`admin-link ${tab==='categories'?'active':''}`} onClick={()=>setTab('categories')}>Categories</button>
-          <button className={`admin-link ${tab==='applications'?'active':''}`} onClick={()=>setTab('applications')}>Applications {apps.length?`(${apps.length})`:''}</button>
-          <button className={`admin-link ${tab==='reports'?'active':''}`} onClick={()=>setTab('reports')}>Reports {reports.filter(r=>r.status==='open').length?`(${reports.filter(r=>r.status==='open').length})`:''}</button>
-            <div className="muted" style={{ margin:'var(--space-12) var(--space-xs) var(--space-xs)', fontSize:'.85rem' }}>Quick links</div>
-            <Link className="admin-link" to="/editor">New Post</Link>
-            <Link className="admin-link" to="/dashboard">Author Dashboard</Link>
-            <Link className="admin-link" to="/profile">Profile</Link>
-            <Link className="admin-link" to="/">Home</Link>
-          </nav>
-        </aside>
-        <main className="admin-content">
-          {tab==='dashboard' && <DashboardView />}
-          {tab==='users' && <UsersView />}
-          {tab==='pending' && <PendingView />}
-          {tab==='categories' && <CategoriesView />}
-          {tab==='applications' && <ApplicationsView />}
-          {tab==='reports' && <ReportsView />}
-        </main>
-      </div>
-    </div>
+      {tab==='dashboard' && <DashboardView />}
+      {tab==='users' && <UsersView />}
+      {tab==='pending' && <PendingView />}
+      {tab==='categories' && <CategoriesView />}
+      {tab==='applications' && <ApplicationsView />}
+      {tab==='reports' && <ReportsView />}
+    </AdminLayout>
   )
 }


### PR DESCRIPTION
## Summary
- centralize admin panel layout with reusable component and badge counts
- ensure footer stays at bottom using app-shell flex layout
- refine admin sidebar styling for improved UX

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package 'eslint-config-prettier')*


------
https://chatgpt.com/codex/tasks/task_e_68bfedf7b70c8322bf87583e0cd437fc