### PR TITLE
Add page-level loading with Suspense and Loader component

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,25 +1,28 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import { Suspense, lazy } from 'react'
 import Navbar from './components/Navbar'
 import Subnav from './components/Subnav.jsx'
 import Footer from './components/Footer.jsx'
-import Home from './pages/Home'
-import Categories from './pages/Categories'
-import Category from './pages/Category'
-import Login from './pages/Login'
-import Register from './pages/Register'
-import ForgotPassword from './pages/ForgotPassword.jsx'
-import ResetPassword from './pages/ResetPassword.jsx'
-import Preview from './pages/Preview.jsx'
-import Dashboard from './pages/Dashboard'
-import Editor from './pages/Editor'
-import Profile from './pages/Profile'
-import Article from './pages/Article'
-import Admin from './pages/Admin'
-import AdminCategories from './pages/AdminCategories.jsx'
+import Loader from './components/Loader.jsx'
 import ProtectedRoute from './routes/ProtectedRoute'
-import Feed from './pages/Feed'
-import Author from './pages/Author'
 import { useAuth } from './state/AuthContext.jsx'
+
+const Home = lazy(() => import('./pages/Home'))
+const Categories = lazy(() => import('./pages/Categories'))
+const Category = lazy(() => import('./pages/Category'))
+const Login = lazy(() => import('./pages/Login'))
+const Register = lazy(() => import('./pages/Register'))
+const ForgotPassword = lazy(() => import('./pages/ForgotPassword.jsx'))
+const ResetPassword = lazy(() => import('./pages/ResetPassword.jsx'))
+const Preview = lazy(() => import('./pages/Preview.jsx'))
+const Dashboard = lazy(() => import('./pages/Dashboard'))
+const Editor = lazy(() => import('./pages/Editor'))
+const Profile = lazy(() => import('./pages/Profile'))
+const Article = lazy(() => import('./pages/Article'))
+const Admin = lazy(() => import('./pages/Admin'))
+const AdminCategories = lazy(() => import('./pages/AdminCategories.jsx'))
+const Feed = lazy(() => import('./pages/Feed'))
+const Author = lazy(() => import('./pages/Author'))
 
 function GlobalUI() {
   const { ui } = useAuth()
@@ -50,33 +53,35 @@ function App() {
         <Subnav />
         <GlobalUI />
         <main className="app-main">
-          <Routes>
-            <Route path="/" element={<Home />} />
-            <Route path="/login" element={<Login />} />
-            <Route path="/forgot-password" element={<ForgotPassword />} />
-            <Route path="/reset-password" element={<ResetPassword />} />
-            <Route path="/register" element={<Register />} />
-            <Route path="/categories" element={<Categories />} />
-            <Route path="/category/:slug" element={<Category />} />
-            <Route path="/article/:id" element={<Article />} />
-            <Route path="/a/:slug" element={<Article />} />
-            <Route path="/p/:token" element={<Preview />} />
-            <Route path="/author/:id" element={<Author />} />
-            <Route element={<ProtectedRoute roles={["reader","author","admin"]} />}> 
-              <Route path="/feed" element={<Feed />} />
-            </Route>
-            <Route element={<ProtectedRoute roles={["author","admin"]} />}> 
-              <Route path="/dashboard" element={<Dashboard />} />
-              <Route path="/editor/:id?" element={<Editor />} />
-            </Route>
-            <Route element={<ProtectedRoute roles={["reader","author","admin"]} />}> 
-              <Route path="/profile" element={<Profile />} />
-            </Route>
-            <Route element={<ProtectedRoute roles={["admin"]} />}> 
-              <Route path="/admin" element={<Admin />} />
-              <Route path="/admin/categories" element={<AdminCategories />} />
-            </Route>
-          </Routes>
+          <Suspense fallback={<Loader />}>
+            <Routes>
+              <Route path="/" element={<Home />} />
+              <Route path="/login" element={<Login />} />
+              <Route path="/forgot-password" element={<ForgotPassword />} />
+              <Route path="/reset-password" element={<ResetPassword />} />
+              <Route path="/register" element={<Register />} />
+              <Route path="/categories" element={<Categories />} />
+              <Route path="/category/:slug" element={<Category />} />
+              <Route path="/article/:id" element={<Article />} />
+              <Route path="/a/:slug" element={<Article />} />
+              <Route path="/p/:token" element={<Preview />} />
+              <Route path="/author/:id" element={<Author />} />
+              <Route element={<ProtectedRoute roles={["reader","author","admin"]} />}>
+                <Route path="/feed" element={<Feed />} />
+              </Route>
+              <Route element={<ProtectedRoute roles={["author","admin"]} />}>
+                <Route path="/dashboard" element={<Dashboard />} />
+                <Route path="/editor/:id?" element={<Editor />} />
+              </Route>
+              <Route element={<ProtectedRoute roles={["reader","author","admin"]} />}>
+                <Route path="/profile" element={<Profile />} />
+              </Route>
+              <Route element={<ProtectedRoute roles={["admin"]} />}>
+                <Route path="/admin" element={<Admin />} />
+                <Route path="/admin/categories" element={<AdminCategories />} />
+              </Route>
+            </Routes>
+          </Suspense>
         </main>
         <Footer />
       </div>

--- a/client/src/components/Loader.jsx
+++ b/client/src/components/Loader.jsx
@@ -1,0 +1,10 @@
+import React from 'react'
+
+export default function Loader() {
+  return (
+    <div className="page-loader" role="status" aria-live="polite">
+      <div className="spinner" />
+      <span className="sr-only">Loading…</span>
+    </div>
+  )
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -210,6 +210,9 @@ h1,h2,h3 { margin: var(--space-10) 0 }
 .spinner { width:var(--space-36); height:var(--space-36); border-radius:999px; border:var(--space-3) solid rgba(255,255,255,.2); border-top-color: #c7d2fe; animation: spin .8s linear infinite }
 @keyframes spin { to { transform: rotate(360deg) } }
 .sr-only { position:absolute; width:var(--space-1); height:var(--space-1); padding:0; margin:-var(--space-1); overflow:hidden; clip:rect(0,0,0,0); border:0 }
+/* Page-level loader */
+.page-loader { display:flex; align-items:center; justify-content:center; min-height:50vh }
+
 
 /* Reading progress bar */
 .read-progress { position:fixed; top:0; left:0; height:var(--space-3); background: linear-gradient(90deg, #a5b4fc, #34d399); z-index:100; transition: width .1s ease; box-shadow:0 0 var(--space-10) rgba(99,102,241,.4) }


### PR DESCRIPTION
## Summary
- introduce reusable Loader component and accompanying page-level styles
- lazy-load page routes and show Loader fallback via React Suspense

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bff3048ef483229f441e135b9ba0f3